### PR TITLE
Added Elastic Security credentials feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ $ evtx2es /evtxfiles/ # The Path is recursively expanded to file1~6.evtx.
 --scheme:
   Scheme to use (http, or https)
   (default: http)
+
+--login:
+  The login to use if Elastic Security is enable
+  (default: )
+
+--pwd:
+  The password linked to the login provided
+  (default: )
 ```
 
 ### Examples
@@ -92,6 +100,14 @@ $ evtx2es /path/to/your/file.evtx --host=localhost --port=9200 --index=foo --siz
 if __name__ == '__main__':
     evtx2es('/path/to/your/file.evtx', host=localhost, port=9200, index='foo', size=500)
 ```
+
+With credentials for Elastic Security:
+```
+$ evtx2es /path/to/your/file.evtx --host=localhost --port=9200 --index=foo --size=500 --login=elastic --pwd=******
+```
+
+Note: The current version does not verify the certificate.
+
 
 ## Extra
 


### PR DESCRIPTION
I have added the possibility to use credentials, in case the elasticsearch database has Elastic Security feature enabled.

I deactivated the verification of the certificate at the moment, but I will try to add it in a future update.

I have tested the program with Python 3.8.0 and Elasticsearch 7.9.3.

Enjoy!