### PR TITLE
Feature / Fix: Maximize data recovery from carved EVTX files by preventing parser crashes

### DIFF
--- a/src/evtx2es/models/Evtx2es.py
+++ b/src/evtx2es/models/Evtx2es.py
@@ -39,7 +39,14 @@ class SafeMultiprocessingMixin:
 
 
 def generate_chunks(chunk_size: int, iterable: Iterable) -> Generator:
-    """Generate arbitrarily sized chunks from iterable objects.
+    """Generate arbitrarily sized chunks from iterable objects, maximizing data recovery.
+
+    When dealing with EVTX files recovered via carving from unallocated space, 
+    the data is frequently incomplete, overwritten, or heavily corrupted (garbage data).
+    This function replaces `itertools.islice` with manual iteration to gracefully 
+    handle both expected parsing errors (like `RuntimeError` for bad chunk headers) 
+    and unexpected exceptions. The primary goal is to salvage as many intact 
+    records as possible without crashing the entire extraction process.
 
     Args:
         chunk_size (int): Chunk sizes.
@@ -48,11 +55,37 @@ def generate_chunks(chunk_size: int, iterable: Iterable) -> Generator:
     Yields:
         Generator: List
     """
-    i = iter(iterable)
-    piece = list(islice(i, chunk_size))
-    while piece:
-        yield piece
-        piece = list(islice(i, chunk_size))
+    iterator = iter(iterable)
+    piece = []
+
+    while True:
+        try:
+            # Extract a single record at a time to isolate parsing errors
+            item = next(iterator)
+            piece.append(item)
+
+            # Yield the chunk when it reaches the specified size
+            if len(piece) == chunk_size:
+                yield piece
+                piece = []
+
+        except StopIteration:
+            # End of the iterable reached; yield any remaining records in the buffer
+            if piece:
+                yield piece
+            break
+
+        except RuntimeError as e:
+            # Catch specific EVTX parser errors (e.g., corrupted chunk headers).
+            # Bypassing these allows us to recover subsequent valid records.
+            continue
+
+        except Exception as e:
+            # Catch-all for unexpected errors caused by heavily corrupted carved data.
+            # In forensic carving, encountering unpredictable garbage data is common.
+            # We catch these to ensure the parser survives and extracts all possible data
+            # instead of halting the entire pipeline.
+            continue
 
 
 def _parse_event_data(record: dict) -> dict:


### PR DESCRIPTION
**Title:** Feature / Fix: Maximize data recovery from carved EVTX files by preventing parser crashes

**Description:**
### Context
In digital forensics, EVTX files recovered via data carving from unallocated space are frequently incomplete, partially overwritten, or contain unpredictable garbage data. The primary objective when parsing these files is to salvage every possible intact record, rather than failing strictly upon encountering corruption.

### The Problem
Currently, the `generate_chunks` function utilizes `list(islice(i, chunk_size))`. Because `islice` consumes the iterator in blocks, encountering a single corrupted record or a broken chunk header raises an unhandled exception (most commonly a `RuntimeError` thrown by the underlying `PyEvtxParser`). This causes the entire `evtx2json` / `evtx2es` process to crash, halting the ingestion pipeline and losing potentially recoverable data located after the corrupted section.

### The Solution
This PR refactors `generate_chunks` to iterate through the records one by one using a `try...except` block. 

* It explicitly catches `RuntimeError` to bypass known chunk header parsing failures.
* It also includes a generic `Exception` catch block. While catching generic exceptions is usually discouraged, it is strictly necessary in this forensic context. Carved data can introduce highly unpredictable structural anomalies (pure garbage data) that trigger unforeseen errors. 

By skipping the corrupted segments instead of crashing, the tool becomes significantly more robust and aligns perfectly with the fault-tolerant behavior expected from forensic data recovery pipelines.